### PR TITLE
:bug: fix end date creation

### DIFF
--- a/src/arena/SprintCreation.js
+++ b/src/arena/SprintCreation.js
@@ -173,7 +173,7 @@ function SprintCreation(props) {
       coachId: props.user.mentor,
       // hopefully the Date type doesn't give us problems, could be a place to debug
       startDate: startDate,
-      endDate: new Date(Date.now(startDate) + 432000000),
+      endDate: new Date(startDate.getTime() + 432000000),
       events: [],
       studySessions: [],
       createdAt: Date.now(),


### PR DESCRIPTION
Pull-Request for `paretOS`

## Description
- Date was previously calculating from current time, I think
- Instead take startDate convert to milliseconds and add 5 days in milliseconds, of course
- A possible improvement could be to set the end date to 11:59:59:999 possibly by adding setUTCHours(23,59,59,999)

## Relates to
- #232 or whichever ticket number the pr is addressing

## Reviewers

